### PR TITLE
"cssAnimation" to "animation" Replacement in Frontend Markup

### DIFF
--- a/src/utils/fn.ts
+++ b/src/utils/fn.ts
@@ -15,12 +15,15 @@ export function dataStringify(data: Object, type: string): string | null {
 	csv += Object.entries(data)
 		.map((item) => {
 			if (type === 'sequence') {
-				return item[1].action + ':' + item[1].value;
+				if (item[1].action === 'cssAnimation') {
+					return `animation:${item[1].value}`;
+				}
+				return `${item[1].action}:${item[1].value}`;
 			} else if (type === 'defaults') {
 				return null;
 			}
 			return item[0] !== 'steps' && item[0] !== 'scene'
-				? item[0] + ':' + item[1]
+				? `${item[0]}:${item[1]}`
 				: null;
 		})
 		.join(';');


### PR DESCRIPTION
**Description:**
In response to issue #4, I've addressed the problem where the "cssAnimation" attribute in the frontend markup was not being correctly replaced with "animation". This issue was causing the custom animation module to malfunction when "animation CSS" was selected in the timeline sequence.

I have made the necessary modifications to ensure that "cssAnimation" is replaced with "animation" as expected. After implementing this change, I can confirm that the custom animation module functions correctly for me.

close #4